### PR TITLE
Adeguate minimum SDK for both plugins

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 26
+        minSdkVersion 18
     }
 }
 

--- a/ios/immutable_device_identifier.podspec
+++ b/ios/immutable_device_identifier.podspec
@@ -16,7 +16,7 @@ A new Flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.dependency 'KeychainAccess'
-  s.platform = :ios, '12.0'
+  s.platform = :ios, '9.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/ios/immutable_device_identifier.podspec
+++ b/ios/immutable_device_identifier.podspec
@@ -16,7 +16,7 @@ A new Flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.dependency 'KeychainAccess'
-  s.platform = :ios, '14.0'
+  s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
Hi creche-studio,
I loved your plugin for unique identification, but I noticed you placed higher SDK than necessary.
Based on what plugin you used on iOS and Android, I lowered the SDK to the minimum necessary.
I tested it and currently using it in my app on production, and it is working fine.

Thanks for the idea :)