### PR TITLE
feat(android): specify Android namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace = "studio.creche.immutable_device_identifier"
+    
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
It's necessary to specify namespace for Flutter >=3.27. Despite that, you may want to bump package version and publish update on pub.dev